### PR TITLE
Fix production build missing proxy URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN npm ci
 # Copy source files
 COPY . .
 
-# Build argument for proxy URL (passed via --build-arg in CI/CD)
-ARG VITE_API_PROXY_URL
+# Build argument for proxy URL (defaults to production proxy)
+ARG VITE_API_PROXY_URL=https://recoverylm-proxy-627579746441.us-central1.run.app
 ENV VITE_API_PROXY_URL=$VITE_API_PROXY_URL
 
 # Build the app


### PR DESCRIPTION
## Summary
- Add default value to `VITE_API_PROXY_URL` ARG in Dockerfile so the proxy URL is baked into the frontend bundle at build time

## Problem
Cloud Run builds had an empty proxy URL because the Dockerfile ARG had no default and no `--build-arg` was being passed. This caused the app to fall back to direct API mode and fail with "VITE_ANTHROPIC_API_KEY is not set".

## Test plan
- [x] Deployed to production and verified Remi chat works

Fixes #6

🤖 Generated with [Claude Code](https://claude.ai/code)