### PR TITLE
Fix landing page not scrolling on mobile

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -14,23 +14,6 @@
   /* Ensure full height on mobile */
   html, body, #app {
     height: 100%;
-    overflow: hidden;
-  }
-
-  /* Landing page override - enable scrolling */
-  html.landing-page,
-  body.landing-page,
-  html.landing-page #app {
-    height: auto;
-    overflow: auto;
-  }
-
-  /* Onboarding page override - enable scrolling */
-  html.onboarding-page,
-  body.onboarding-page,
-  html.onboarding-page #app {
-    height: auto;
-    overflow: auto;
   }
 
   /* Selection color */

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -30,10 +30,6 @@ const scrollToSection = (id: string) => {
 const observerRef = ref<IntersectionObserver | null>(null)
 
 onMounted(() => {
-  // Enable scrolling on this page (override global overflow:hidden)
-  document.documentElement.classList.add('landing-page')
-  document.body.classList.add('landing-page')
-
   observerRef.value = new IntersectionObserver(
     (entries) => {
       entries.forEach((entry) => {
@@ -52,10 +48,6 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  // Restore global overflow:hidden
-  document.documentElement.classList.remove('landing-page')
-  document.body.classList.remove('landing-page')
-
   observerRef.value?.disconnect()
 })
 </script>

--- a/src/pages/OnboardingPage.vue
+++ b/src/pages/OnboardingPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import type { OnboardingStep, RecoveryPhilosophy, RecoveryStage, VulnerabilityPattern } from '@/types'
 import { generateId, today } from '@/types'
@@ -7,17 +7,6 @@ import { useVault } from '@/composables/useVault'
 
 const router = useRouter()
 const { saveProfile, saveEmergencyContact: saveEmergencyContactToVault } = useVault()
-
-// Enable scrolling on mobile by overriding global overflow:hidden
-onMounted(() => {
-  document.documentElement.classList.add('onboarding-page')
-  document.body.classList.add('onboarding-page')
-})
-
-onUnmounted(() => {
-  document.documentElement.classList.remove('onboarding-page')
-  document.body.classList.remove('onboarding-page')
-})
 
 // Onboarding state
 const currentStep = ref<OnboardingStep>('welcome')


### PR DESCRIPTION
## Summary
- Remove global `overflow: hidden` from `html`/`body` in `main.css` — `MainLayout` already handles its own overflow containment
- Remove fragile class-toggling workarounds from `LandingPage.vue` and `OnboardingPage.vue` that attempted to dynamically re-enable scrolling (unreliable on iOS Safari)
- Delete the now-unnecessary `.landing-page` and `.onboarding-page` CSS override blocks

Closes #10

## Test plan
- [ ] Landing page scrolls fully to the footer on mobile (iOS Safari, Chrome Android)
- [ ] Onboarding page scrolls on mobile
- [ ] Main app chat view does NOT show unwanted body-level scrolling
- [ ] `npm run typecheck` passes
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)