### PR TITLE
Fix blank chat on greeting failure and mobile landing page scroll

### DIFF
--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -11,9 +11,14 @@
     --border: 51 65 85;         /* slate-700 RGB */
   }
 
-  /* Ensure full height on mobile */
+  /* Ensure full height on mobile — use min-height so pages taller
+     than the viewport (e.g. landing page) can scroll naturally on
+     mobile touch browsers and in PWA standalone mode. */
   html, body {
-    height: 100%;
+    min-height: 100%;
+    touch-action: manipulation;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
   }
 
   #app {

--- a/src/composables/useChat.ts
+++ b/src/composables/useChat.ts
@@ -413,7 +413,18 @@ export function useChat() {
           isGeneratingGreeting.value = false
         }
       })
-    } catch {
+    } catch (e) {
+      console.error('Failed to generate greeting:', e)
+
+      // Remove the empty placeholder message if it was added
+      if (streamingMessageId.value) {
+        const msgIndex = messages.value.findIndex(m => m.id === streamingMessageId.value)
+        if (msgIndex !== -1) {
+          messages.value.splice(msgIndex, 1)
+        }
+      }
+
+      error.value = 'Failed to connect. Please check your connection and try again.'
       isStreaming.value = false
       streamingMessageId.value = null
       isGeneratingGreeting.value = false

--- a/src/pages/LandingPage.vue
+++ b/src/pages/LandingPage.vue
@@ -53,7 +53,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="min-h-screen bg-canvas text-slate-300 antialiased selection:bg-indigo-500/30 selection:text-white overflow-x-hidden">
+  <div class="min-h-screen bg-canvas text-slate-300 antialiased selection:bg-indigo-500/30 selection:text-white">
     <!-- Navbar -->
     <nav class="fixed top-0 w-full z-50 border-b border-slate-800 bg-canvas/80 backdrop-blur-md">
       <div class="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">


### PR DESCRIPTION
## Summary
- **Fixes #5**: `generateGreeting()` catch block now removes the empty placeholder message and sets `error.value`, matching the `onError` callback behavior. Previously a silent failure left an invisible empty message bubble with no loading indicator or error feedback.
- **Fixes mobile landing page scroll**: Removed `overflow-x-hidden` from LandingPage root (broke iOS momentum scrolling), changed `html, body` from `height: 100%` to `min-height: 100%`, and added `touch-action: manipulation`, `overscroll-behavior: contain`, and `-webkit-overflow-scrolling: touch` for reliable touch scrolling in PWA standalone mode.

## Test plan
- [ ] Remove or invalidate `VITE_ANTHROPIC_API_KEY` and open chat — verify error banner appears instead of blank screen
- [ ] Restore API key and open chat — verify greeting generates normally
- [ ] Open landing page on iOS Safari (mobile) — verify smooth vertical scrolling with normal swipe gestures
- [ ] Open landing page in PWA standalone mode on iOS — verify scrolling still works
- [ ] Verify app shell pages (chat, dashboard) still constrain scroll correctly within their own containers