### PR TITLE
Fix widget overflow in chat view on mobile

### DIFF
--- a/src/components/widgets/CheckinWidget.vue
+++ b/src/components/widgets/CheckinWidget.vue
@@ -144,7 +144,7 @@ const complete = async () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-emerald-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/CommitmentWidget.vue
+++ b/src/components/widgets/CommitmentWidget.vue
@@ -73,7 +73,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-indigo-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/DentsWidget.vue
+++ b/src/components/widgets/DentsWidget.vue
@@ -122,7 +122,7 @@ const logOutcome = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-indigo-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/EvidenceWidget.vue
+++ b/src/components/widgets/EvidenceWidget.vue
@@ -76,7 +76,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-lg w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-purple-400 font-bold flex items-center gap-2">
@@ -108,7 +108,7 @@ const complete = () => {
             <p class="text-slate-300 text-sm line-through">{{ thoughtInput }}</p>
           </div>
 
-          <div class="grid grid-cols-2 gap-3">
+          <div class="grid grid-cols-2 gap-3 [&>*]:min-w-0">
             <div class="p-2 bg-red-900/10 border border-red-500/20 rounded">
               <div class="text-red-400 text-xs mb-1">Evidence For ({{ evidenceFor.length }})</div>
               <ul class="text-xs text-slate-400 space-y-0.5">
@@ -156,7 +156,7 @@ const complete = () => {
       </div>
 
       <!-- Evidence Grid -->
-      <div class="grid grid-cols-2 gap-3 mb-4">
+      <div class="grid grid-cols-2 gap-3 mb-4 [&>*]:min-w-0">
         <!-- Evidence FOR the thought -->
         <div class="p-3 bg-red-900/10 border border-red-500/20 rounded-lg">
           <h4 class="text-red-400 text-sm font-medium mb-2">Evidence FOR</h4>

--- a/src/components/widgets/GratitudeWidget.vue
+++ b/src/components/widgets/GratitudeWidget.vue
@@ -58,7 +58,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-lg w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-emerald-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/NetworkWidget.vue
+++ b/src/components/widgets/NetworkWidget.vue
@@ -66,7 +66,7 @@ const getContactIcon = (method: string) => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-pink-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/SelfAppreciationWidget.vue
+++ b/src/components/widgets/SelfAppreciationWidget.vue
@@ -91,7 +91,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-lg w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-amber-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/StoicWidget.vue
+++ b/src/components/widgets/StoicWidget.vue
@@ -68,7 +68,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-lg w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-cyan-400 font-bold flex items-center gap-2">
@@ -103,7 +103,7 @@ const complete = () => {
           Focus your energy on what you can control. Accept what you cannot.
         </p>
 
-        <div class="grid grid-cols-2 gap-3 text-left">
+        <div class="grid grid-cols-2 gap-3 text-left [&>*]:min-w-0">
           <div class="p-3 bg-emerald-900/20 border border-emerald-500/30 rounded-lg">
             <div class="text-emerald-400 text-xs font-medium mb-2">Focus On ({{ canControl.length }})</div>
             <ul class="text-sm text-slate-300 space-y-1">
@@ -132,7 +132,7 @@ const complete = () => {
     </Transition>
 
     <!-- Two Columns -->
-    <div v-if="!showSummary" class="grid grid-cols-2 gap-3">
+    <div v-if="!showSummary" class="grid grid-cols-2 gap-3 [&>*]:min-w-0">
       <!-- Can Control Column -->
       <div class="p-3 bg-emerald-900/10 border border-emerald-500/20 rounded-lg">
         <h4 class="text-emerald-400 text-sm font-medium mb-2">What I CAN Control</h4>

--- a/src/components/widgets/TapeWidget.vue
+++ b/src/components/widgets/TapeWidget.vue
@@ -73,7 +73,7 @@ const complete = () => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-amber-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/ThoughtLogWidget.vue
+++ b/src/components/widgets/ThoughtLogWidget.vue
@@ -124,7 +124,7 @@ const disputePrompts = [
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-lg w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-indigo-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/UrgeSurfWidget.vue
+++ b/src/components/widgets/UrgeSurfWidget.vue
@@ -244,7 +244,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="widget-container p-4 my-3 max-w-md w-full">
+  <div class="widget-container p-4 my-3 max-w-full w-full">
     <!-- Header -->
     <div class="flex justify-between items-center mb-4 border-b border-slate-700 pb-3">
       <h3 class="text-blue-400 font-bold flex items-center gap-2">

--- a/src/components/widgets/WidgetRenderer.vue
+++ b/src/components/widgets/WidgetRenderer.vue
@@ -36,7 +36,7 @@ const handleComplete = (result: unknown) => {
 </script>
 
 <template>
-  <div v-if="component" class="widget-wrapper">
+  <div v-if="component" class="widget-wrapper overflow-hidden">
     <Suspense>
       <component
         :is="component"
@@ -45,7 +45,7 @@ const handleComplete = (result: unknown) => {
         @complete="handleComplete"
       />
       <template #fallback>
-        <div class="widget-container p-4 my-3 max-w-md w-full animate-pulse">
+        <div class="widget-container p-4 my-3 max-w-full w-full animate-pulse">
           <div class="h-4 bg-slate-700 rounded w-1/3 mb-4"></div>
           <div class="h-20 bg-slate-700 rounded mb-2"></div>
           <div class="h-8 bg-slate-700 rounded w-1/4 ml-auto"></div>
@@ -53,7 +53,7 @@ const handleComplete = (result: unknown) => {
       </template>
     </Suspense>
   </div>
-  <div v-else class="widget-container p-4 my-3 max-w-md w-full border-red-500/30">
+  <div v-else class="widget-container p-4 my-3 max-w-full w-full border-red-500/30">
     <p class="text-red-400 text-sm">Unknown widget: {{ widget.id }}</p>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- **Fixes #27**: All 11 widget components used fixed `max-w-lg`/`max-w-md` (512px/448px) which overflowed the chat message container on narrow mobile screens
- Replaced with `max-w-full` so widgets respect their parent container width
- Added `[&>*]:min-w-0` on `grid-cols-2` containers in StoicWidget and EvidenceWidget to prevent grid children from expanding beyond column boundaries
- Added `overflow-hidden` on WidgetRenderer wrapper as a safety net

## Test plan
- [ ] Open Stoic (Dichotomy of Control) widget on mobile — verify two-column layout and inputs stay within bounds
- [ ] Open Evidence Examination widget on mobile — verify grid columns don't overflow
- [ ] Test all other widgets (DENTS, Tape, UrgeSurf, Checkin, Commitment, Network, ThoughtLog, Gratitude, SelfAppreciation) render within chat container on mobile
- [ ] Verify widgets still display correctly on desktop/wider screens