### PR TITLE
fix: swap journal button hierarchy — Save Entry is now primary (#32)

### DIFF
--- a/src/pages/JournalPage.vue
+++ b/src/pages/JournalPage.vue
@@ -324,14 +324,14 @@ onMounted(async () => {
             <button
               @click="saveEntry"
               :disabled="!entryContent.trim() || isSaving"
-              class="flex-1 py-3 px-4 rounded-lg border border-slate-600 text-slate-300 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              class="flex-1 py-3 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-800 disabled:cursor-not-allowed text-white font-semibold transition-colors"
             >
               {{ isSaving ? 'Saving...' : 'Save Entry' }}
             </button>
             <button
               @click="analyzeWithRemi"
               :disabled="!entryContent.trim() || isSaving"
-              class="flex-1 py-3 px-4 rounded-lg bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-800 disabled:cursor-not-allowed text-white font-semibold transition-colors flex items-center justify-center gap-2"
+              class="flex-1 py-3 px-4 rounded-lg border border-slate-600 text-slate-300 hover:bg-slate-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
             >
               <Send :size="18" />
               {{ isSaving ? 'Saving...' : 'Analyze with Remi' }}


### PR DESCRIPTION
Reverse the visual treatment of the two journal action buttons so that "Save Entry" uses the filled indigo primary style and "Analyze with Remi" uses the outline/ghost secondary style. Saving is the dominant action for most journal entries and should carry the stronger visual weight.

Closes #32

https://claude.ai/code/session_01LAfNQQWn6F3XXnVXVMF4Eb